### PR TITLE
don't bind FMP to the package phase

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -98,7 +98,6 @@
                         <executions>
                             <execution>
                                 <id>fmp</id>
-                                <phase>package</phase>
                                 <goals>
                                     <goal>resource</goal>
                                     <goal>build</goal>


### PR DESCRIPTION
Various goals of the Fabric8 Maven plugin are by default bound
to reasonable Maven lifecycle phases. Binding FMP to `package`
explicitly overrides these defaults and causes issues.
For example, if the `fabric8:resource` goal runs in `package`,
it means that the JAR won't contain the `META-INF/fabric8` stuff
(because it simply isn't there yet when the JAR is built).
Consequently, when Failsafe puts the JAR on the test classpath 
instead of `target/classes` (as it is doing since version 2.19),
Arquillian Cube won't be able to find `*.yml` files it needs.