### PR TITLE
don't deploy the SSO server via env.dependencies

### DIFF
--- a/src/test/resources/arquillian.xml
+++ b/src/test/resources/arquillian.xml
@@ -6,7 +6,6 @@
     <property name="namespace.use.current">true</property>
     <property name="env.init.enabled">true</property>
     <property name="enableImageStreamDetection">false</property>
-    <property name="env.dependencies">file://${basedir}/.openshiftio/service.sso.yaml</property>
   </extension>
 
 </arquillian>


### PR DESCRIPTION
The test expects the SSO server to be already deployed, so we shouldn't configure Arquillian Cube to deploy it again.

Could you please also do the same in the `redhat` branch? Thanks.